### PR TITLE
feat: カレンダーのグリッド表示とレイアウトの最適化

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import type { DailyRecord, Level } from "./types/types";
+import type { DailyRecord } from "./types/types";
 import { Square } from "./components/Square";
 
 // ダミーデータ
@@ -14,24 +14,46 @@ const dummyData: DailyRecord = {
     "2026-02-10": 3,
     "2026-02-11": 4,
     "2026-02-12": 0,
+    "2026-02-14": 4,
     "2026-02-13": 1,
+    "2026-02-15": 2,
+    "2026-02-16": 3,
+    "2026-02-17": 4,
+    "2026-02-18": 0,
+    "2026-02-19": 1,
+    "2026-02-20": 2,
+    "2026-02-21": 3,
+    "2026-02-22": 4,
+    "2026-02-23": 0,
+    "2026-02-24": 1,
+    "2026-02-25": 2,
+    "2026-02-26": 3,
+    "2026-02-27": 4,
+    "2026-02-28": 0,
+    "2026-03-01": 1,
+    "2026-03-02": 2,
+    "2026-03-03": 3,
 };
 
 function App() {
     const [records, setRecords] = useState<DailyRecord>(dummyData);
 
     // オブジェクトを「キー（日付）」と「値（Level）」のペアの配列に変換
-    const recordEntries = Object.entries(records);
+    const recordEntries = Object.entries(records).sort((a, b) => a[0].localeCompare(b[0]));
 
     return (
-        <div className="container p-6 space-y-4">
+        <div className="p-6 space-y-4">
             <h1 className="text-3xl font-bold">Habit Tracker</h1>
-            <div className="flex flex-wrap gap-1 w-full max-w-4xl">
-                {/* map の引数で分割代入を使って受け取る */}
-                {recordEntries.map(([date, level]) => (
-                    // タイルを並べる
-                    <Square key={date} level={level} />
-                ))}
+            <div className="card">
+                <div className="card-body space-y-4 items-start">
+                    <div className="inline-flex flex-wrap flex-col gap-1 max-h-34">
+                        {/* map の引数で分割代入を使って受け取る */}
+                        {recordEntries.map(([date, level]) => (
+                            // タイルを並べる
+                            <Square date={date} key={date} level={level} />
+                        ))}
+                    </div>
+                </div>
             </div>
         </div>
     );

--- a/src/components/Square.tsx
+++ b/src/components/Square.tsx
@@ -1,6 +1,7 @@
 import type { Level } from "../types/types";
 
 interface SquareProps {
+    date: string;
     level: Level;
 }
 
@@ -13,9 +14,14 @@ const levelColors: Record<Level, string> = {
     4: "bg-green-800", // 一番濃い緑
 };
 
-export const Square = ({ level }: SquareProps) => {
+export const Square = ({ date, level }: SquareProps) => {
     // マッピングからクラスを取得
     const colorClass = levelColors[level];
 
-    return <div className={`w-4 h-4 rounded-sm ${colorClass} transition-colors duration-200 cursor-pointer`}></div>;
+    return (
+        <div
+            title={date}
+            className={`w-4 h-4 rounded-sm ${colorClass} transition-colors duration-200 cursor-pointer`}
+        ></div>
+    );
 };


### PR DESCRIPTION
## 変更内容
- データを日付順にソート
- タイルの並べ方のスタイルをブラッシュアップ
- タイルにマウスオーバーで日付を表示

Closes #7 